### PR TITLE
Remove logging of sensitive things.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,6 @@ node[:deploy].each do |application, deploy|
     recursive true
   end
 
-  Chef::Log.info("DEPLOY ATTRIBUTES: #{deploy.inspect}")
   opsworks_deploy do
     deploy_data deploy
     app application


### PR DESCRIPTION
Remove logging of deploy attributes because they contain things like private keys.